### PR TITLE
Added: variable slide duration

### DIFF
--- a/jquery.fractionslider.js
+++ b/jquery.fractionslider.js
@@ -418,6 +418,16 @@
 				vars.init = false;
 				slideChangeControler(true);
 			} else {
+			
+				/** ---- Implementation for variable slide duration  ---- **/
+                var slideDuration = slider.children('.slide:eq(' + vars.currentSlide + ')').attr("data-duration");
+                if(slideDuration != undefined){
+                    timeout = slideDuration;
+                }else{
+                    timeout = options.timeout;
+                }
+                /* ----- */
+				
 				// timeout after slide is complete
 				timeouts.push(setTimeout(function() {
 					// stops the slider after first slide (only when slide count = 1)


### PR DESCRIPTION
I added the support of attribute `data-duration` in slides elements. 
If not set the slide duration is the time set in slider parameters, if set then the slide duration is the one specified in the attribute.

Example :
```html
<div class="slide" data-in="scrollTop" data-duration="3000">
            <!-- Slides Elements ... -->
</div>
<div class="slide" data-in="scrollTop"><!-- Default duration set in slider parameters -->
            <!-- Slides Elements ... -->
</div>
```

Not a big deal but it helped in a personnal project.

