### PR TITLE
added slidetransitioncallback

### DIFF
--- a/jquery.fractionslider.js
+++ b/jquery.fractionslider.js
@@ -58,7 +58,8 @@
 				'resumeCallback' : null,
 				'nextSlideCallback' : null,
 				'prevSlideCallback' : null,
-				'pagerCallback' : null
+				'pagerCallback' : null,
+				'onSlideTransitionCallback' : null
 			}, option);
 
 			return this.each(function() {
@@ -241,7 +242,9 @@
 
 			nextSlide();
 			
-			methodeCallback(options.startNextSlideCallback);
+			methodeCallback(function(){
+				options.startNextSlideCallback();
+			});
 		}
 
 
@@ -496,6 +499,9 @@
 						break;
 				}
 			}
+			methodeCallback(function(){
+				options.onSlideTransitionCallback();
+			});
 		}
 
 		// starts a slide


### PR DESCRIPTION
IE doesn't respect overflow:hidden on video elements in this slider.  This causes video elements to flicker and be displayed outside the slide container as the slide is being transitioned out.  By allowing for a callback in this place, one possible solution is to do the following:

``` javascript
$('#slider').fractionslider({
  onSlideTransitionCallback: function() {
    $('#slider').find('video, .ui-video-background').fadeOut(0).delay(500).fadeIn(0);
  }
});
```
